### PR TITLE
Fixed wp-gfm-footer clearfix

### DIFF
--- a/css/markdown.css
+++ b/css/markdown.css
@@ -59,7 +59,12 @@
 
 .wp-gfm-footer {
   margin: 5px 0;
+}
+
+.wp-gfm-footer::after {
+  content: '';
   clear: both;
+  display: block;
 }
 
 .wp-gfm-ad {

--- a/sass/_footer.scss
+++ b/sass/_footer.scss
@@ -1,6 +1,10 @@
 .wp-gfm-footer {
   margin: 5px 0;
+}
+.wp-gfm-footer::after {
+  content: '';
   clear: both;
+  display: block;
 }
 .wp-gfm-ad {
   display: inline;


### PR DESCRIPTION
便利なプラグインをありがとうございます。:)

"Add a link of wp-gfm plugin to content"  にチェックを入れると表示される wp-gfm-footer に clearfix が必要でしたので追加しました。
