### PR TITLE
Clean img attribute at powered by tag

### DIFF
--- a/markdown.php
+++ b/markdown.php
@@ -54,7 +54,7 @@ class WP_GFM {
 			add_action( 'wp_enqueue_scripts', array( $this, 'wp_enqueue_styles' ) );
 		}
 
-		$this->ad_html = '<div class="wp-gfm-ad"><span class="wp-gfm-powered-by">Markdown with by <img alt="❤" src="https://s.w.org/images/core/emoji/72x72/2764.png" width="10" height="10" scale="0"> <a href="https://github.com/makotokw/wp-gfm" target="_blank">wp-gfm</a></span></div>';
+		$this->ad_html = '<div class="wp-gfm-ad"><span class="wp-gfm-powered-by">Markdown with by <img alt="❤" src="https://s.w.org/images/core/emoji/72x72/2764.png" width="10" height="10"> <a href="https://github.com/makotokw/wp-gfm" target="_blank">wp-gfm</a></span></div>';
 	}
 
 	function wp_enqueue_styles() {


### PR DESCRIPTION
こんにちは。

先日 [HTML Validator](https://validator.w3.org/nu/) を利用した際に、下記のエラーが表示されていることに気づきました。

Powered by を表示している img tag の attribute `scale="0"` に対するもののようなのですが、内部的になんらかの役割を果たしているのでしょうか。

もしかすると不要なのかもと思ったのですが、ご確認お願いします。:)

```
Error: Attribute scale not allowed on element img at this point.
From line 35, column 124; to line 35, column 258
n with by <img alt="❤" src="https://i0.wp.com/s.w.org/images/core/emoji/72x72/2764.png?resize=10%2C10&#038;ssl=1" scale="0" data-recalc-dims="1"> <a hr
Attributes for element img:
Global attributes
alt - Replacement text for use when images are not available
src - Address of the resource
srcset - Images to use in different situations (e.g., high-resolution displays, small monitors, etc)
sizes - Image sizes between breakpoints
crossorigin - How the element handles crossorigin requests
usemap - Name of image map to use
ismap - Whether the image is a server-side image map
width - Horizontal dimension
height - Vertical dimension
referrerpolicy - Referrer policy for fetches initiated by the element
longdesc - A url that provides a link to an expanded description of the image, defined in [html-longdesc]
```

Fix HTML Validation Error.
Attribute scale not allowed on element img.
